### PR TITLE
Bug SOL-67752: Fix and expand unit test coverage for protozero library

### DIFF
--- a/include/perfetto/protozero/scattered_stream_writer.h
+++ b/include/perfetto/protozero/scattered_stream_writer.h
@@ -126,8 +126,7 @@ class PERFETTO_EXPORT ScatteredStreamWriter {
   void WriteBytesSlowPath(const uint8_t* src, size_t size);
 
   // Reserves a fixed amount of bytes to be backfilled later. The reserved range
-  // is guaranteed to be contiguous and not span across chunks. |size| has to be
-  // <= than the size of a new buffer returned by the Delegate::GetNewBuffer().
+  // is fixed to four-bytes in size, and may span across chunks.
   ReservedBytes ReserveBytes(bool zeroReservedBytes);
 
   // Fast (but unsafe) version of the above. The caller must have previously

--- a/src/protozero/message.cc
+++ b/src/protozero/message.cc
@@ -153,7 +153,7 @@ Message* Message::BeginNestedMessageInternal(uint32_t field_id) {
   // The length of the nested message cannot be known upfront. So right now
   // just reserve the bytes to encode the size after the nested message is done.
   message->set_size_field(
-      stream_writer_->ReserveBytes(proto_utils::kMessageLengthFieldSize));
+      stream_writer_->ReserveBytes(false));
   size_ += proto_utils::kMessageLengthFieldSize;
 
   nested_message_ = message;

--- a/src/protozero/message_unittest.cc
+++ b/src/protozero/message_unittest.cc
@@ -105,6 +105,21 @@ class MessageTest : public ::testing::Test {
     return buffer_->GetBytesAsString(old_readback_pos, num_bytes);
   }
 
+  // Properly initializes and exposes the size field of the messasge 
+  // so that we can read it later for the purpose of testing.
+  // Tests related to the size_field spanning across multiple chunks
+  // are handled in scattered_stream_writer_unittest.cc. Here, we
+  // assume that the size field is always contained in a single chunk.
+  uint8_t* SetSizeField(Message* msg) {
+    if (stream_writer_->write_ptr() == nullptr) {
+      stream_writer_->Reset(buffer_.get()->GetNewBuffer());
+    }
+    ScatteredStreamWriter::ReservedBytes reserved_bytes =
+        stream_writer_->ReserveBytes(false);
+    msg->set_size_field(reserved_bytes);
+    return reserved_bytes.buf_[0];
+  }
+
   static void BuildNestedMessages(Message* msg,
                                   uint32_t max_depth,
                                   uint32_t depth = 0) {
@@ -240,8 +255,7 @@ TEST_F(MessageTest, AppendScatteredBytes) {
 // on finalization.
 TEST_F(MessageTest, BackfillSizeOnFinalization) {
   Message* root_msg = NewMessage();
-  uint8_t root_msg_size[proto_utils::kMessageLengthFieldSize] = {};
-  root_msg->set_size_field(&root_msg_size[0]);
+  uint8_t* msg_size = SetSizeField(root_msg);
   root_msg->AppendVarInt(1, 0x42);
 
   FakeChildMessage* nested_msg_1 =
@@ -256,17 +270,22 @@ TEST_F(MessageTest, BackfillSizeOnFinalization) {
 
   root_msg->inc_size_already_written(6);
 
-  // The value returned by Finalize() should be == the full size of |root_msg|.
+  // The value returned by Finalize() should be == the full size of |root_msg|
+  // excluding the bytes reserved for the size field.
   EXPECT_EQ(217u, root_msg->Finalize());
-  EXPECT_EQ(217u, GetNumSerializedBytes());
 
-  // However the size written in the size field should take into account the
-  // inc_size_already_written() call and be equal to 118 - 6 = 112, encoded
+  // The value returned by GetNumSerializedBytes() will include the bytes reserved
+  // for the size_field.
+  EXPECT_EQ(221u, GetNumSerializedBytes());
+
+  // The size written in the size field should take into account the
+  // inc_size_already_written() call and be equal to 217 - 6 = 211, encoded
   // in a rendundant varint encoding of kMessageLengthFieldSize bytes.
-  EXPECT_STREQ("\xD3\x81\x80\x00", reinterpret_cast<char*>(root_msg_size));
+  EXPECT_STREQ("\xD3\x81\x80\x00", reinterpret_cast<char*>(msg_size));
 
-  // Skip 2 bytes for the 0x42 varint + 1 byte for the |nested_msg_1| preamble.
-  GetNextSerializedBytes(3);
+  // Skip 4 bytes for the size field, 2 bytes for the 0x42 varint
+  // + 1 byte for the |nested_msg_1| preamble.
+  GetNextSerializedBytes(7);
 
   // Check that the size of |nested_msg_1| was backfilled. Its size is:
   // 203 bytes for |nest_mesg_2| (see below) + 5 bytes for its preamble +
@@ -294,7 +313,8 @@ TEST_F(MessageTest, StressTest) {
   // here on the full buffer hash.
   std::string full_buf = GetNextSerializedBytes(GetNumSerializedBytes());
   size_t buf_hash = SimpleHash(full_buf);
-  EXPECT_EQ(0xf9e32b65, buf_hash);
+  size_t expected_hash = 3743529221;
+  EXPECT_EQ(expected_hash, buf_hash);
 }
 
 TEST_F(MessageTest, DeeplyNested) {
@@ -306,7 +326,8 @@ TEST_F(MessageTest, DeeplyNested) {
 
   std::string full_buf = GetNextSerializedBytes(GetNumSerializedBytes());
   size_t buf_hash = SimpleHash(full_buf);
-  EXPECT_EQ(0xc0fde419, buf_hash);
+  size_t expected_hash = 864756345;
+  EXPECT_EQ(expected_hash, buf_hash);
 }
 
 TEST_F(MessageTest, DestructInvalidMessageHandle) {
@@ -322,50 +343,47 @@ TEST_F(MessageTest, MessageHandle) {
   FakeRootMessage* msg2 = NewMessage();
   FakeRootMessage* msg3 = NewMessage();
   FakeRootMessage* ignored_msg = NewMessage();
-  uint8_t msg1_size[proto_utils::kMessageLengthFieldSize] = {};
-  uint8_t msg2_size[proto_utils::kMessageLengthFieldSize] = {};
-  uint8_t msg3_size[proto_utils::kMessageLengthFieldSize] = {};
-  msg1->set_size_field(&msg1_size[0]);
-  msg2->set_size_field(&msg2_size[0]);
-  msg3->set_size_field(&msg3_size[0]);
+  uint8_t* msg1_size = SetSizeField(msg1);
+  uint8_t* msg2_size = SetSizeField(msg2);
+  uint8_t* msg3_size = SetSizeField(msg3);
 
   // Test that the handle going out of scope causes the finalization of the
   // target message and triggers the optional callback.
   {
     MessageHandle<FakeRootMessage> handle1(msg1);
     handle1->AppendBytes(1 /* field_id */, kTestBytes, 1 /* size */);
-    ASSERT_EQ(0u, msg1_size[0]);
+    ASSERT_EQ(0u, *msg1_size);  // |msg1| should not be finalized yet.
   }
-  ASSERT_EQ(0x83u, msg1_size[0]);
+  ASSERT_EQ(0x83u, *msg1_size);
 
   // Test that the handle can be late initialized.
   MessageHandle<FakeRootMessage> handle2(ignored_msg);
   handle2 = MessageHandle<FakeRootMessage>(msg2);
   handle2->AppendBytes(1 /* field_id */, kTestBytes, 2 /* size */);
-  ASSERT_EQ(0u, msg2_size[0]);  // |msg2| should not be finalized yet.
+  ASSERT_EQ(0u, *msg2_size);  // |msg2| should not be finalized yet.
 
   // Test that std::move works and does NOT cause finalization of the moved
   // message.
   MessageHandle<FakeRootMessage> handle_swp(ignored_msg);
   handle_swp = std::move(handle2);
-  ASSERT_EQ(0u, msg2_size[0]);  // msg2 should be NOT finalized yet.
+  ASSERT_EQ(0u, *msg2_size);  // msg2 should not be finalized yet.
   handle_swp->AppendBytes(2 /* field_id */, kTestBytes, 3 /* size */);
 
   MessageHandle<FakeRootMessage> handle3(msg3);
   handle3->AppendBytes(1 /* field_id */, kTestBytes, 4 /* size */);
-  ASSERT_EQ(0u, msg3_size[0]);  // msg2 should be NOT finalized yet.
+  ASSERT_EQ(0u, *msg3_size);  // msg2 should not be finalized yet.
 
   // Both |handle3| and |handle_swp| point to a valid message (respectively,
   // |msg3| and |msg2|). Now move |handle3| into |handle_swp|.
   handle_swp = std::move(handle3);
-  ASSERT_EQ(0x89u, msg2_size[0]);  // |msg2| should be finalized at this point.
+  ASSERT_EQ(0x89u, *msg2_size);  // |msg2| should be finalized at this point.
 
   // At this point writing into handle_swp should actually write into |msg3|.
   ASSERT_EQ(msg3, &*handle_swp);
   handle_swp->AppendBytes(2 /* field_id */, kTestBytes, 8 /* size */);
   MessageHandle<FakeRootMessage> another_handle(ignored_msg);
   handle_swp = std::move(another_handle);
-  ASSERT_EQ(0x90u, msg3_size[0]);  // |msg3| should be finalized at this point.
+  ASSERT_EQ(0x90u, *msg3_size);  // |msg3| should be finalized at this point.
 
 #if PERFETTO_DCHECK_IS_ON()
   // In developer builds w/ PERFETTO_DCHECK on a finalized message should
@@ -383,33 +401,29 @@ TEST_F(MessageTest, MessageHandle) {
   {
     auto* nested_msg_1 = NewMessage()->BeginNestedMessage<FakeChildMessage>(3);
     MessageHandle<FakeChildMessage> child_handle_1(nested_msg_1);
-    uint8_t* size_msg_1 = nested_msg_1->size_field();
-    memset(size_msg_1, 0, proto_utils::kMessageLengthFieldSize);
+    uint8_t* size_msg_1 = SetSizeField(nested_msg_1);
     child_handle_1->AppendVarInt(1, 0x11);
 
     auto* nested_msg_2 = NewMessage()->BeginNestedMessage<FakeChildMessage>(2);
-    size_msg_2 = nested_msg_2->size_field();
-    memset(size_msg_2, 0, proto_utils::kMessageLengthFieldSize);
+    size_msg_2 = SetSizeField(nested_msg_2);
     MessageHandle<FakeChildMessage> child_handle_2(nested_msg_2);
     child_handle_2->AppendVarInt(2, 0xFF);
 
     // |nested_msg_1| should not be finalized yet.
-    ASSERT_EQ(0u, size_msg_1[0]);
+    ASSERT_EQ(0u, *size_msg_1);
 
     // This move should cause |nested_msg_1| to be finalized, but not
     // |nested_msg_2|, which will be finalized only after the current scope.
     child_handle_1 = std::move(child_handle_2);
-    ASSERT_EQ(0x82u, size_msg_1[0]);
-    ASSERT_EQ(0u, size_msg_2[0]);
+    ASSERT_EQ(0x82u, *size_msg_1);
+    ASSERT_EQ(0u, *size_msg_2);
   }
-  ASSERT_EQ(0x83u, size_msg_2[0]);
+  ASSERT_EQ(0x83u, *size_msg_2);
 }
 
 TEST_F(MessageTest, MoveMessageHandle) {
   FakeRootMessage* msg = NewMessage();
-  uint8_t msg_size[proto_utils::kMessageLengthFieldSize] = {};
-  msg->set_size_field(&msg_size[0]);
-
+  uint8_t* msg_size = SetSizeField(msg);
   // Test that the handle going out of scope causes the finalization of the
   // target message.
   {
@@ -417,9 +431,9 @@ TEST_F(MessageTest, MoveMessageHandle) {
     MessageHandle<FakeRootMessage> handle2{};
     handle1->AppendBytes(1 /* field_id */, kTestBytes, 1 /* size */);
     handle2 = std::move(handle1);
-    ASSERT_EQ(0u, msg_size[0]);
+    ASSERT_EQ(0u, *msg_size);
   }
-  ASSERT_EQ(0x83u, msg_size[0]);
+  ASSERT_EQ(0x83u, *msg_size);
 }
 
 }  // namespace

--- a/src/protozero/message_unittest.cc
+++ b/src/protozero/message_unittest.cc
@@ -105,19 +105,13 @@ class MessageTest : public ::testing::Test {
     return buffer_->GetBytesAsString(old_readback_pos, num_bytes);
   }
 
-  // Properly initializes and exposes the size field of the messasge 
-  // so that we can read it later for the purpose of testing.
-  // Tests related to the size_field spanning across multiple chunks
-  // are handled in scattered_stream_writer_unittest.cc. Here, we
-  // assume that the size field is always contained in a single chunk.
-  uint8_t* SetSizeField(Message* msg) {
-    if (stream_writer_->write_ptr() == nullptr) {
-      stream_writer_->Reset(buffer_.get()->GetNewBuffer());
-    }
+  // Sets size field using ScatteredStreamWriter::ReserveBytes() to reserve
+  // space for the size field in the message. This is used to backfill the size
+  // field at the end of the message, after all fields have been written.
+  void SetSizeField(Message* msg) {
     ScatteredStreamWriter::ReservedBytes reserved_bytes =
         stream_writer_->ReserveBytes(false);
     msg->set_size_field(reserved_bytes);
-    return reserved_bytes.buf_[0];
   }
 
   static void BuildNestedMessages(Message* msg,
@@ -255,7 +249,8 @@ TEST_F(MessageTest, AppendScatteredBytes) {
 // on finalization.
 TEST_F(MessageTest, BackfillSizeOnFinalization) {
   Message* root_msg = NewMessage();
-  uint8_t* msg_size = SetSizeField(root_msg);
+  SetSizeField(root_msg);
+  uint8_t* msg_size = root_msg->size_field().buf_[0];
   root_msg->AppendVarInt(1, 0x42);
 
   FakeChildMessage* nested_msg_1 =
@@ -343,9 +338,12 @@ TEST_F(MessageTest, MessageHandle) {
   FakeRootMessage* msg2 = NewMessage();
   FakeRootMessage* msg3 = NewMessage();
   FakeRootMessage* ignored_msg = NewMessage();
-  uint8_t* msg1_size = SetSizeField(msg1);
-  uint8_t* msg2_size = SetSizeField(msg2);
-  uint8_t* msg3_size = SetSizeField(msg3);
+  SetSizeField(msg1);
+  SetSizeField(msg2);
+  SetSizeField(msg3);
+  uint8_t* msg1_size = msg1->size_field().buf_[0];
+  uint8_t* msg2_size = msg2->size_field().buf_[0];
+  uint8_t* msg3_size = msg3->size_field().buf_[0];
 
   // Test that the handle going out of scope causes the finalization of the
   // target message and triggers the optional callback.
@@ -401,11 +399,13 @@ TEST_F(MessageTest, MessageHandle) {
   {
     auto* nested_msg_1 = NewMessage()->BeginNestedMessage<FakeChildMessage>(3);
     MessageHandle<FakeChildMessage> child_handle_1(nested_msg_1);
-    uint8_t* size_msg_1 = SetSizeField(nested_msg_1);
+    SetSizeField(nested_msg_1);
+    uint8_t* size_msg_1 = nested_msg_1->size_field().buf_[0];
     child_handle_1->AppendVarInt(1, 0x11);
 
     auto* nested_msg_2 = NewMessage()->BeginNestedMessage<FakeChildMessage>(2);
-    size_msg_2 = SetSizeField(nested_msg_2);
+    SetSizeField(nested_msg_2);
+    size_msg_2 = nested_msg_2->size_field().buf_[0];
     MessageHandle<FakeChildMessage> child_handle_2(nested_msg_2);
     child_handle_2->AppendVarInt(2, 0xFF);
 
@@ -423,7 +423,8 @@ TEST_F(MessageTest, MessageHandle) {
 
 TEST_F(MessageTest, MoveMessageHandle) {
   FakeRootMessage* msg = NewMessage();
-  uint8_t* msg_size = SetSizeField(msg);
+  SetSizeField(msg);
+  uint8_t* msg_size = msg->size_field().buf_[0];
   // Test that the handle going out of scope causes the finalization of the
   // target message.
   {

--- a/src/protozero/proto_utils_unittest.cc
+++ b/src/protozero/proto_utils_unittest.cc
@@ -163,20 +163,20 @@ TEST(ProtoUtilsTest, VarIntEncodingNegative) {
 TEST(ProtoUtilsTest, RedundantVarIntEncoding) {
   uint8_t buf[kMessageLengthFieldSize];
 
-  WriteRedundantVarInt(0, buf);
+  WriteRedundantVarInt(0, buf, kMessageLengthFieldSize);
   EXPECT_EQ(0, memcmp("\x80\x80\x80\x00", buf, sizeof(buf)));
 
-  WriteRedundantVarInt(1, buf);
+  WriteRedundantVarInt(1, buf, kMessageLengthFieldSize);
   EXPECT_EQ(0, memcmp("\x81\x80\x80\x00", buf, sizeof(buf)));
 
-  WriteRedundantVarInt(0x80, buf);
+  WriteRedundantVarInt(0x80, buf, kMessageLengthFieldSize);
   EXPECT_EQ(0, memcmp("\x80\x81\x80\x00", buf, sizeof(buf)));
 
-  WriteRedundantVarInt(0x332211, buf);
+  WriteRedundantVarInt(0x332211, buf, kMessageLengthFieldSize);
   EXPECT_EQ(0, memcmp("\x91\xC4\xCC\x01", buf, sizeof(buf)));
 
   // Largest allowed length.
-  WriteRedundantVarInt(0x0FFFFFFF, buf);
+  WriteRedundantVarInt(0x0FFFFFFF, buf, kMessageLengthFieldSize);
   EXPECT_EQ(0, memcmp("\xFF\xFF\xFF\x7F", buf, sizeof(buf)));
 }
 

--- a/src/protozero/scattered_stream_writer.cc
+++ b/src/protozero/scattered_stream_writer.cc
@@ -55,8 +55,6 @@ void ScatteredStreamWriter::WriteBytesSlowPath(const uint8_t* src,
   }
 }
 
-// TODO(primiano): perf optimization: I suspect that at the end this will always
-// be called with |size| == 4, in which case we might just hardcode it.
 ScatteredStreamWriter::ReservedBytes
 ScatteredStreamWriter::ReserveBytes(bool zeroReservedBytes) {
   constexpr size_t size = ReservedBytes::kFieldSize;
@@ -84,11 +82,24 @@ ScatteredStreamWriter::ReserveBytes(bool zeroReservedBytes) {
     Extend();
     PERFETTO_DCHECK(write_ptr_ + size - ret.firstSz_ <= cur_range_.end);
 
-    ret.buf_[1] = write_ptr_;
+    if (ret.buf_[0] == nullptr) {
+      // If the first buffer was not set, it means we entered with an uninitialized
+      // write_ptr_. The call to Extend() initialized the write_ptr_ to the start of 
+      // a new chunk, so point the first ReservedBytes buf to it and update the 
+      // firstSz_ and write_ptr_ accordingly.
+      ret.buf_[0] = write_ptr_;
+      ret.firstSz_ = size;
+      write_ptr_ += ret.firstSz_;
+    } else {
+      // Otherwise, we did not have enough space in the first chunk to reserve
+      // the full size, so reserve the rest in the second chunk and update the
+      // write_ptr_ accordingly.
+      ret.buf_[1] = write_ptr_;
+      write_ptr_ += size - ret.firstSz_;
+    }
     if (zeroReservedBytes) {
         memset(write_ptr_, 0, size - ret.firstSz_);
     }
-    write_ptr_ += size - ret.firstSz_;
   } else {
     write_ptr_ += ret.firstSz_;
   }

--- a/src/protozero/scattered_stream_writer.cc
+++ b/src/protozero/scattered_stream_writer.cc
@@ -97,14 +97,14 @@ ScatteredStreamWriter::ReserveBytes(bool zeroReservedBytes) {
       ret.buf_[1] = write_ptr_;
       write_ptr_ += size - ret.firstSz_;
     }
-    if (zeroReservedBytes) {
-        memset(write_ptr_, 0, size - ret.firstSz_);
-    }
   } else {
     write_ptr_ += ret.firstSz_;
   }
   if (zeroReservedBytes) {
     memset(ret.buf_[0], 0, ret.firstSz_);
+    if (ret.buf_[1]) {
+      memset(ret.buf_[1], 0, size - ret.firstSz_);
+    }
   }
   return ret;
 }

--- a/src/protozero/scattered_stream_writer_unittest.cc
+++ b/src/protozero/scattered_stream_writer_unittest.cc
@@ -35,7 +35,6 @@ TEST(ScatteredStreamWriterTest, ScatteredWrites) {
 
   const uint8_t kOneByteBuf[] = {0x40};
   const uint8_t kThreeByteBuf[] = {0x50, 0x51, 0x52};
-  const uint8_t kFourByteBuf[] = {0x60, 0x61, 0x62, 0x63};
   uint8_t kTwentyByteBuf[20];
   for (uint8_t i = 0; i < sizeof(kTwentyByteBuf); ++i)
     kTwentyByteBuf[i] = 0xA0 + i;
@@ -55,47 +54,51 @@ TEST(ScatteredStreamWriterTest, ScatteredWrites) {
 
   // This starts at offset 1, to make sure we don't hardcode any assumption
   // about alignment.
-  uint8_t* reserved_range_1 = ssw.ReserveBytes(4);
+  auto reserved_range_1 = ssw.ReserveBytes(false);
+  // Check that the four bytes are reserved correctly.
   EXPECT_EQ(2u, delegate.chunks().size());
   EXPECT_EQ(3u, ssw.bytes_available());
 
   ssw.WriteByte(0xFF);
   ssw.WriteBytes(kThreeByteBuf, sizeof(kThreeByteBuf));
+  // Check that writing past the end of the chunk after the reserved
+  // bytes causes another extension, and that the reserved bytes
+  // are still not backfilled.
   EXPECT_EQ(3u, delegate.chunks().size());
   EXPECT_EQ(7u, ssw.bytes_available());
+  EXPECT_EQ("4000000000FF5051", delegate.GetChunkAsString(1));
 
-  uint8_t* reserved_range_2 = ssw.ReserveBytes(4);
+
+  auto reserved_range_2 = ssw.ReserveBytes(false);
   ssw.WriteBytes(kTwentyByteBuf, sizeof(kTwentyByteBuf));
   EXPECT_EQ(6u, delegate.chunks().size());
   EXPECT_EQ(7u, ssw.bytes_available());
+  EXPECT_EQ("5200000000A0A1A2", delegate.GetChunkAsString(2));
+  
 
-  // Writing reserved bytes should not change the bytes_available().
-  memcpy(reserved_range_1, kFourByteBuf, sizeof(kFourByteBuf));
-  memcpy(reserved_range_2, kFourByteBuf, sizeof(kFourByteBuf));
+  // Backfilling the reserved bytes should not change the bytes_available().
+  reserved_range_1.WriteRedundantVarInt(0x01020304);   // Encodes to 0x84 0x86 0x88 0x08
+  reserved_range_2.WriteRedundantVarInt(0x01020304);
   EXPECT_EQ(6u, delegate.chunks().size());
   EXPECT_EQ(7u, ssw.bytes_available());
+  
+  // Confirm the reserved bytes were backfilled successfully.
+  EXPECT_EQ("4084868808FF5051", delegate.GetChunkAsString(1));
+  EXPECT_EQ("5284868808A0A1A2", delegate.GetChunkAsString(2));
 
-  // Check that reserving more bytes than what left creates a brand new chunk
-  // even if the previous one is not exhausted
+  // After for-loop, only 2 bytes are left in the current chunk.
   for (uint8_t i = 0; i < 5; ++i)
     ssw.WriteByte(0xFF);
-  memcpy(ssw.ReserveBytes(4), kFourByteBuf, sizeof(kFourByteBuf));
-  memcpy(ssw.ReserveBytesUnsafe(3), kThreeByteBuf, sizeof(kThreeByteBuf));
-  memcpy(ssw.ReserveBytes(3), kThreeByteBuf, sizeof(kThreeByteBuf));
-  memcpy(ssw.ReserveBytesUnsafe(1), kOneByteBuf, sizeof(kOneByteBuf));
-  memcpy(ssw.ReserveBytes(1), kOneByteBuf, sizeof(kOneByteBuf));
-
-  EXPECT_EQ(8u, delegate.chunks().size());
-  EXPECT_EQ(3u, ssw.bytes_available());
-
-  EXPECT_EQ("0001020304050607", delegate.GetChunkAsString(0));
-  EXPECT_EQ("4060616263FF5051", delegate.GetChunkAsString(1));
-  EXPECT_EQ("5260616263A0A1A2", delegate.GetChunkAsString(2));
-  EXPECT_EQ("A3A4A5A6A7A8A9AA", delegate.GetChunkAsString(3));
-  EXPECT_EQ("ABACADAEAFB0B1B2", delegate.GetChunkAsString(4));
   EXPECT_EQ("B3FFFFFFFFFF0000", delegate.GetChunkAsString(5));
-  EXPECT_EQ("6061626350515200", delegate.GetChunkAsString(6));
-  EXPECT_EQ("5051524040000000", delegate.GetChunkAsString(7));
+
+  // Check that reserving more bytes than what left causes reserved bytes to span across
+  // multiple chunks. Write to these bytes immediately. Should see that the write
+  // (0x84 0x86 0x88 0x08) is split across two chunks.
+  ssw.ReserveBytes(false).WriteRedundantVarInt(0x01020304);
+  EXPECT_EQ(7u, delegate.chunks().size());
+  EXPECT_EQ(6u, ssw.bytes_available());
+  EXPECT_EQ("B3FFFFFFFFFF8486", delegate.GetChunkAsString(5));
+  EXPECT_EQ("8808000000000000", delegate.GetChunkAsString(6));
 
   // Finally reset the writer to a new buffer.
   uint8_t other_buffer[8] = {0};

--- a/src/tracing/core/trace_writer_for_testing.cc
+++ b/src/tracing/core/trace_writer_for_testing.cc
@@ -84,7 +84,7 @@ TraceWriterForTesting::NewTracePacket() {
 
   auto packet = TraceWriter::TracePacketHandle(cur_packet_.get());
   packet->set_size_field(
-      stream_.ReserveBytes(protozero::proto_utils::kMessageLengthFieldSize));
+      stream_.ReserveBytes(true));
   return packet;
 }
 


### PR DESCRIPTION
### What is the purpose of this change?
- Update protozero library and unit tests so that they are buildable and reflect changes to the ReservedBytes implementation
- Change ReservedBytes slightly to match older implementation which safeguards against using a null write_ptr_ when a new ScatteredStreamWriter is created

### How is this accomplished?
- Fixed compilation errors in unit tests related to change in implementation of ReservedBytes
- Investigated failing tests and fixed failures introduced by not updating the tests to reflect the changed behavior of ReservedBytes
- Expanded test coverage for scattered stream writer so that writing to multiple chunks via ReservedBytes is covered
- Removed test coverage that is no longer relevant after ReservedBytes changes (ex. size of ReservedBytes is not hardcoded, so testing multiple buffer sizes with this method is irrelevant)
- Added helper method in MessageTest to initialize the size field for the purposes of testing
- Fixed comments throughout library which contain outdated information
- Fixed function calls to ReservedBytes which contained outdated arguments
- Added some if checks to ReservedBytes to ensure the first buf of the struct is always properly initialized with a sane value

### Anything reviews should focus on/be aware of?
-

### What testing if any was performed?
- Built and ran the unit tests alongside the full library following the README instructions, all compile and pass now
- Ran maketests_vm with the changes to the files in the build of the broker repo, saw no issues.

<!--start_gitstream_placeholder-->
### ✨ PR Description


Purpose: Fix and enhance protozero message handling by updating ReserveBytes implementation to properly handle multi-chunk spans and improve test coverage.

Main changes:
- Fixed ReserveBytes to correctly handle reservations spanning multiple chunks
- Updated message.cc to use fixed-size 4-byte reservations for length fields
- Added SetSizeField helper in tests to simplify creating reserved bytes
- Updated test expectations with correct hash values and improved coverage
- Clarified documentation on reserved byte behavior in scattered streams

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
